### PR TITLE
ENH: Format numbers

### DIFF
--- a/webapp_photo_luminescence/tabs/h_figure_tab.py
+++ b/webapp_photo_luminescence/tabs/h_figure_tab.py
@@ -104,7 +104,7 @@ def update_graph(
                 tr.peak_wavelength,
                 annotation=dict(
                     text=f"Wavelength: {tr.peak_wavelength:.2f} nm",
-                    hovertext=f"Intensity: {tr.peak_intensity:.0f}"
+                    hovertext=f"Intensity: {tr.peak_intensity:.4g}"
                 )
             )
     if show_FWHM_range:
@@ -114,7 +114,7 @@ def update_graph(
                 fillcolor=px.colors.qualitative.Set1[i],
                 opacity=0.10,
                 annotation=dict(
-                    text=f"FWHM: {tr.FWHM:.0f} nm",
+                    text=f"FWHM: {tr.FWHM:.3g} nm",
                     hovertext=""
                     f"Left: {tr.half_range[0]:.2f} nm<br>"
                     f"Right: {tr.half_range[1]:.2f} nm"
@@ -123,7 +123,7 @@ def update_graph(
     fig.update_traces(
         hovertemplate=""
         "Wavelength: %{x:.2f} nm<br>"
-        "Intensity: %{y:.0f}<br>"
+        "Intensity: %{y:.4g}<br>"
         "<extra></extra>"
     )
     fig.update_layout(

--- a/webapp_photo_luminescence/tabs/v_figure_tab.py
+++ b/webapp_photo_luminescence/tabs/v_figure_tab.py
@@ -131,15 +131,15 @@ def update_graph(
                 line=dict(color="black"),
                 name=f"Double Exponential Approximation "
                 f"a : b = {wr.df.attrs['fit']['a']}:{wr.df.attrs['fit']['b']}, "
-                f"τ₁ = {wr.df.attrs['fit']['tau1']:.2f} ns, "
-                f"τ₂ = {wr.df.attrs['fit']['tau2']:.2f} ns"
+                f"τ₁ = {wr.df.attrs['fit']['tau1']:.3g} ns, "
+                f"τ₂ = {wr.df.attrs['fit']['tau2']:.3g} ns"
             ) for wr in wrs if "fit" in wr.df.attrs
         ]
     )
     fig.update_traces(
         hovertemplate=""
-        "Time: %{x:.2f} ns<br>"
-        "Intensity: %{y:.0fs}<br>"
+        "Time: %{x:.3g} ns<br>"
+        "Intensity: %{y:.4g}<br>"
         "<extra></extra>"
     )
     fig.update_layout(


### PR DESCRIPTION
Format numbers as follows.

- Wavelength is `.2f`
- Time (include relaxation time) is `.3g`
- Intensity is `.4g`

## Issues
- https://github.com/Waseda-TakeuchiLab/webapp-photo-luminescence/issues/5