### PR TITLE
BUG: Typos in update_upload_dir

### DIFF
--- a/webapp_photo_luminescence/tabs/upload.py
+++ b/webapp_photo_luminescence/tabs/upload.py
@@ -62,8 +62,8 @@ last_uploaded_store = dcc.Store(
     dash.Output(upload_dir_store, "data"),
     dash.Input(upload_dir_store, "data")
 )
-def update_upload_dir(_: dict[str, str] | None) -> str:
-    if upload_dir_store:
+def update_upload_dir(upload_dir: str | None) -> str:
+    if upload_dir:
         raise dash.exceptions.PreventUpdate
     if not os.path.exists(UPLOAD_BASEDIR):
         os.mkdir(UPLOAD_BASEDIR)


### PR DESCRIPTION
## Issue Description
`upload_dir_store` should not be used in a callback function.

https://github.com/Waseda-TakeuchiLab/webapp-photo-luminescence/blob/898e3d2406b660a8a37da4c00ccc32a668b3bb67/webapp_photo_luminescence/tabs/upload.py#L61-L71

## Expected Behavior
The function should be:

```python
@dash.callback(
    dash.Output(upload_dir_store, "data"),
    dash.Input(upload_dir_store, "data")
)
def update_upload_dir(upload_dir: str | None) -> str:
    if upload_dir:
        raise dash.exceptions.PreventUpdate
    if not os.path.exists(UPLOAD_BASEDIR):
        os.mkdir(UPLOAD_BASEDIR)
    tempdir = tempfile.mkdtemp(dir=UPLOAD_BASEDIR)
    return tempdir
```

## Version
v0.1.1